### PR TITLE
Bump '@ic-reactor /react' to stable version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@ic-reactor/react": "1.5.5-beta.0",
+        "@ic-reactor/react": "^1.6.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -1089,9 +1089,9 @@
       "dev": true
     },
     "node_modules/@ic-reactor/core": {
-      "version": "1.5.4-beta.0",
-      "resolved": "https://registry.npmjs.org/@ic-reactor/core/-/core-1.5.4-beta.0.tgz",
-      "integrity": "sha512-P/0gnTdpT/HMSF1lclqAqR/Wwa0CkSz8TqW1RGD9sHsMuxv+vixHfUjvl1Xvf/8VL2Z3ulaUbroUuShm5YjCRg==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@ic-reactor/core/-/core-1.6.2.tgz",
+      "integrity": "sha512-IuBA2WtdfPkXPVCjPppNxXm9jRpUorZEA7HPa0hyqV6bA4L67STsXhC7ICxgWEWJQTAlsejDbQFAPeRqtUVANw==",
       "dependencies": {
         "@dfinity/agent": "^1.2",
         "@dfinity/auth-client": "^1.2",
@@ -1112,11 +1112,12 @@
       }
     },
     "node_modules/@ic-reactor/react": {
-      "version": "1.5.5-beta.0",
-      "resolved": "https://registry.npmjs.org/@ic-reactor/react/-/react-1.5.5-beta.0.tgz",
-      "integrity": "sha512-HvgMrIJL3ik6SnSMvFj+MTc8XF13J8EvWcoXhKydorrrzl/f6LL0zEnI1bopU6yzmZcu/7MTJeheH6ovWAdfMA==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@ic-reactor/react/-/react-1.6.2.tgz",
+      "integrity": "sha512-Ov/BNoCdP4b9OkbvyVLb5/nU48egNhyQBG32BT6XEnY+3/oGBWh+V02uFP6kVVsg7st8tbmxQusIJDk+VFAWtg==",
       "dependencies": {
-        "@ic-reactor/core": "^1.5.4-beta.0",
+        "@ic-reactor/core": "^1.6.2",
+        "react": ">=16.8",
         "zustand-utils": "^1.3"
       },
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@ic-reactor/react": "^1.6.2",
+        "@ic-reactor/react": "^1.7.8",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -473,9 +473,9 @@
       }
     },
     "node_modules/@dfinity/agent": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-1.2.0.tgz",
-      "integrity": "sha512-i9mH0PO73nrhLc9lZv14SWr4muyMcs6uqqlG2SHQtRUFRXbqj4DOhKsU0Sm+kC8eWYCSu65WPKPYwwAR7YM6ug==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-1.3.0.tgz",
+      "integrity": "sha512-gFc2CqjWURv/Th+vxwHIb7Y39TpRZccjyRm8c51LtyAGLYSpSwJDWbzM/y66h++DSSc3A+1DjN/dRT+6ik3xLw==",
       "dependencies": {
         "@noble/curves": "^1.4.0",
         "@noble/hashes": "^1.3.1",
@@ -485,43 +485,43 @@
         "simple-cbor": "^0.4.1"
       },
       "peerDependencies": {
-        "@dfinity/candid": "^1.2.0",
-        "@dfinity/principal": "^1.2.0"
+        "@dfinity/candid": "^1.3.0",
+        "@dfinity/principal": "^1.3.0"
       }
     },
     "node_modules/@dfinity/auth-client": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/auth-client/-/auth-client-1.2.0.tgz",
-      "integrity": "sha512-d0kpSPR6h2q8v4CeZgf+EyIBW2LM2WSlSBpwt0mtP2qllHlWof0Wg+osU6TxT56vaNpQp9+eFg8t1I/FF5VGIg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/auth-client/-/auth-client-1.3.0.tgz",
+      "integrity": "sha512-/1Xn+acHckLh9GlImBRsIEjej0nbD+B0hsoOM8gyimrRrcoxqlSwn+rzjlR2fbVf++rTRRwsQgShG/gfCEXJig==",
       "dependencies": {
         "idb": "^7.0.2"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^1.2.0",
-        "@dfinity/identity": "^1.2.0",
-        "@dfinity/principal": "^1.2.0"
+        "@dfinity/agent": "^1.3.0",
+        "@dfinity/identity": "^1.3.0",
+        "@dfinity/principal": "^1.3.0"
       }
     },
     "node_modules/@dfinity/candid": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-1.2.0.tgz",
-      "integrity": "sha512-L6gV3ODIFC9qNenq3zuRvHrTwH36IM5utVH2wMS5f5eIUeG9fNe+avYLRPBUJwdeX7cM7xhvDgE/m/aN2cZvKQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-1.3.0.tgz",
+      "integrity": "sha512-tt5NYfpv8C+3iKS3Awbi+NAIxjwjIRUOLT+1ys/xpA+6DNEqwgfU8WZu0+bKnf/xlASCyJXUmoMzQ6I01GBp9A==",
       "peerDependencies": {
-        "@dfinity/principal": "^1.2.0"
+        "@dfinity/principal": "^1.3.0"
       }
     },
     "node_modules/@dfinity/identity": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-1.2.0.tgz",
-      "integrity": "sha512-XKFRor195wrXw7yYPh33czh3GJt5shZRRettOcwFYikxAXmOvIlCjATGVGRv2icGBq4AV8SOBJA0lqhnfaUguQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-1.3.0.tgz",
+      "integrity": "sha512-DAqb+dYV20wqJBfMv6RFEyDNPg8FSUVPjK3kXP/gXEDM+w2Viq4/oQdMqm0lWTK8t4+TuxvUS74ULAS7wCYuVQ==",
       "dependencies": {
         "@noble/curves": "^1.2.0",
         "@noble/hashes": "^1.3.1",
         "borc": "^2.1.1"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^1.2.0",
-        "@dfinity/principal": "^1.2.0",
+        "@dfinity/agent": "^1.3.0",
+        "@dfinity/principal": "^1.3.0",
         "@peculiar/webcrypto": "^1.4.0"
       }
     },
@@ -575,9 +575,9 @@
       }
     },
     "node_modules/@dfinity/principal": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-1.2.0.tgz",
-      "integrity": "sha512-7eurqPDL5ptlTTLMJPeiO75FAumXHsWEWDVQaN6XpA3aZtmofNK4Sb5g5Ne9syeuoCJcW3mFBbbFtFNxggxu+g==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-1.3.0.tgz",
+      "integrity": "sha512-04Ly9/VxztgmSk3LeUv1H+aA/8zCfed5gzgydVKBv9U0pk2lcCjUOMhv3G+1UCUSd8GwzrWaSwIsrzrAcHZm/g==",
       "dependencies": {
         "@noble/hashes": "^1.3.1"
       }
@@ -1089,46 +1089,45 @@
       "dev": true
     },
     "node_modules/@ic-reactor/core": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/@ic-reactor/core/-/core-1.6.2.tgz",
-      "integrity": "sha512-IuBA2WtdfPkXPVCjPppNxXm9jRpUorZEA7HPa0hyqV6bA4L67STsXhC7ICxgWEWJQTAlsejDbQFAPeRqtUVANw==",
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@ic-reactor/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-VQnhqmIzDt085g3es0ZDr4ox4fp2L7w2AcX8y2FL2OeS4r8i3v36T8dcy+wwkXHP/IylmV1Tx/Tp2smbTXWR1Q==",
       "dependencies": {
-        "@dfinity/agent": "^1.2",
-        "@dfinity/auth-client": "^1.2",
-        "@dfinity/candid": "^1.2",
-        "@dfinity/identity": "^1.2",
-        "@dfinity/principal": "^1.2",
+        "@dfinity/agent": "^1.3",
+        "@dfinity/auth-client": "^1.3",
+        "@dfinity/candid": "^1.3",
+        "@dfinity/identity": "^1.3",
+        "@dfinity/principal": "^1.3",
         "zustand": "^4.5"
       },
       "engines": {
         "node": ">=10"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^1.2",
-        "@dfinity/auth-client": "^1.2",
-        "@dfinity/candid": "^1.2",
-        "@dfinity/identity": "^1.2",
-        "@dfinity/principal": "^1.2"
+        "@dfinity/agent": "^1.3",
+        "@dfinity/auth-client": "^1.3",
+        "@dfinity/candid": "^1.3",
+        "@dfinity/identity": "^1.3",
+        "@dfinity/principal": "^1.3"
       }
     },
     "node_modules/@ic-reactor/react": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/@ic-reactor/react/-/react-1.6.2.tgz",
-      "integrity": "sha512-Ov/BNoCdP4b9OkbvyVLb5/nU48egNhyQBG32BT6XEnY+3/oGBWh+V02uFP6kVVsg7st8tbmxQusIJDk+VFAWtg==",
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@ic-reactor/react/-/react-1.7.8.tgz",
+      "integrity": "sha512-IFz/ArDpXmrOffXRznf4ywt0s8+gRrwNe2szC1OnfG+3db5ouajY6oAalTmybr1OH7QvWG/rrKhR2ZCmq+HA4A==",
       "dependencies": {
-        "@ic-reactor/core": "^1.6.2",
-        "react": ">=16.8",
+        "@ic-reactor/core": "^1.7.5",
         "zustand-utils": "^1.3"
       },
       "engines": {
         "node": ">=10"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^1.2",
-        "@dfinity/auth-client": "^1.2",
-        "@dfinity/candid": "^1.2",
-        "@dfinity/identity": "^1.2",
-        "@dfinity/principal": "^1.2",
+        "@dfinity/agent": "^1.3",
+        "@dfinity/auth-client": "^1.3",
+        "@dfinity/candid": "^1.3",
+        "@dfinity/identity": "^1.3",
+        "@dfinity/principal": "^1.3",
         "react": ">=16.8",
         "zustand": "4.5"
       }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "postinstall": "mops install"
   },
   "dependencies": {
-    "@ic-reactor/react": "^1.6.2",
+    "@ic-reactor/react": "^1.7.8",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "postinstall": "mops install"
   },
   "dependencies": {
-    "@ic-reactor/react": "1.5.5-beta.0",
+    "@ic-reactor/react": "^1.6.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },


### PR DESCRIPTION
This pump fix this error `node_modules/@ic-reactor/core/dist/utils/helper.js (32:19) Use of eval in "../../node_modules/@ic-reactor/core/dist/utils/helper.js" is strongly discouraged as it poses security risks and may cause issues with minification.` during build process using `vite`/`rollup`